### PR TITLE
allow additional arguments with on_highlighted with mathjax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R:
     person(given = "Etienne", 
            family = "Bacher", 
            role = "ctb", 
-           email = "etienne.bacher@orange.fr")
+           email = "etienne.bacher@protonmail.com")
   )
 Description: Provide step by step guided tours of 'Shiny' applications.
 License: MIT + file LICENSE

--- a/R/steps.R
+++ b/R/steps.R
@@ -127,9 +127,10 @@ Cicerone <- R6::R6Class(
       step = list(element = el, tab_id = tab_id, tab = tab)
 
       if(private$mathjax) {
-        step$onHighlighted <- "function(element){setTimeout(function(){
+        step$onHighlighted <- paste0("function(element){setTimeout(function(){
           MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
-        }, 300)}"   
+        }, 300);", on_highlighted, "}")
+        
       } else {
         if(!is.null(on_highlighted)) step$onHighlighted <- on_highlighted
       }

--- a/R/steps.R
+++ b/R/steps.R
@@ -126,10 +126,13 @@ Cicerone <- R6::R6Class(
 
       step = list(element = el, tab_id = tab_id, tab = tab)
 
-      if(private$mathjax)
-        step$onHighlighted <- paste0("function(element){setTimeout(function(){
+      if(private$mathjax) {
+        step$onHighlighted <- "function(element){setTimeout(function(){
           MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
-        }, 300);", on_highlighted, "}")
+        }, 300)}"   
+      } else {
+        if(!is.null(on_highlighted)) step$onHighlighted <- on_highlighted
+      }
       
       if(!is.null(on_highlight_started)) step$onHighlightStarted <- on_highlight_started
       if(!is.null(on_next)) step$onNext <- on_next

--- a/R/steps.R
+++ b/R/steps.R
@@ -126,16 +126,15 @@ Cicerone <- R6::R6Class(
 
       step = list(element = el, tab_id = tab_id, tab = tab)
 
-      if(!is.null(on_highlighted)) step$onHighlighted <- on_highlighted
+      if(private$mathjax)
+        step$onHighlighted <- paste0("function(element){setTimeout(function(){
+          MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+        }, 300);", on_highlighted, "}")
+      
       if(!is.null(on_highlight_started)) step$onHighlightStarted <- on_highlight_started
       if(!is.null(on_next)) step$onNext <- on_next
 
       if(length(popover)) step$popover <- popover
-
-      if(private$mathjax)
-        step$onHighlighted <- "function(element){setTimeout(function(){
-          MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
-        }, 300)}"   
 
       private$steps <- append(private$steps, list(step))
       invisible(self)


### PR DESCRIPTION
The latest commit that enabled MathJax prevents from passing additional arguments to on_highlighted. This PR corrects this.
Example of misfunction (check the console):
```
library(shiny)

guide <- Cicerone$
  new(mathjax = TRUE)$ # enable MathJax
  step(
    el = "text_inputId",
    title = helpText('Dynamic output 1:  $$\\alpha^2$$'),
    description = "This is where you enter the text you want to print.",
    on_highlighted = "console.log('something')"
  )

ui <- fluidPage(
  withMathJax(), # include MathJax
  use_cicerone(), 
  textInput("text_inputId", "Enter some text"),
  actionButton("submit_inputId", "Submit text")
)

server <- function(input, output){
  
  guide$init()$start()
  
}

shinyApp(ui, server)
```