### PR TITLE
Add a `run_once` argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/node_modules/
 node_modules
 .Rproj.user
 .DS_Store
+.Rhistory

--- a/R/steps.R
+++ b/R/steps.R
@@ -315,6 +315,7 @@ Cicerone <- R6::R6Class(
     steps = list(),
     globals = list(),
     id = NULL,
+    runs = NULL,
     mathjax = FALSE
   )
 )

--- a/R/steps.R
+++ b/R/steps.R
@@ -161,7 +161,8 @@ Cicerone <- R6::R6Class(
         id = private$id
       )
 
-      private$run_once <- run_once
+      if (run_once)
+        private$runs <- 0
       session$sendCustomMessage("cicerone-init", opts)
       invisible(self)
     },
@@ -184,10 +185,11 @@ Cicerone <- R6::R6Class(
 #' @param session A valid Shiny session if `NULL` the function
 #' attempts to get the session with [shiny::getDefaultReactiveDomain()].
     start = function(step = 1, session = NULL){
-      if (private$run_once) {
+      
+      if (private$runs %||% 1 < 1) {
         if(is.null(session))
           session <- shiny::getDefaultReactiveDomain()
-        
+        private$runs <- 1
         step <- step - 1
         session$sendCustomMessage("cicerone-start", list(step = step, id = private$id))
         private$run_once <- FALSE

--- a/R/steps.R
+++ b/R/steps.R
@@ -150,7 +150,8 @@ Cicerone <- R6::R6Class(
 #' 
 #' @param session A valid Shiny session if `NULL` the function
 #' attempts to get the session with [shiny::getDefaultReactiveDomain()].
-    init = function(session = NULL){
+#' @param run_once \code{(lgl)} whether to only run the guide once. **DEFAULT: FALSE**
+    init = function(session = NULL, run_once = FALSE){
       if(is.null(session))
         session <- shiny::getDefaultReactiveDomain()
       
@@ -160,6 +161,7 @@ Cicerone <- R6::R6Class(
         id = private$id
       )
 
+      private$run_once <- run_once
       session$sendCustomMessage("cicerone-init", opts)
       invisible(self)
     },

--- a/R/steps.R
+++ b/R/steps.R
@@ -185,10 +185,11 @@ Cicerone <- R6::R6Class(
 #' @param session A valid Shiny session if `NULL` the function
 #' attempts to get the session with [shiny::getDefaultReactiveDomain()].
     start = function(step = 1, session = NULL){
-      
+      # If private$runs isn't initialized this will be TRUE, IE run_once = FALSE will run contained code
       if (private$runs %||% 0 < 1) {
         if(is.null(session))
           session <- shiny::getDefaultReactiveDomain()
+        # If private$runs is initialized this will return TRUE and increment `private$runs` preventing future runs
         if (isFALSE(private$runs %||% FALSE))
           private$runs <- 1
         step <- step - 1

--- a/R/steps.R
+++ b/R/steps.R
@@ -186,10 +186,11 @@ Cicerone <- R6::R6Class(
 #' attempts to get the session with [shiny::getDefaultReactiveDomain()].
     start = function(step = 1, session = NULL){
       
-      if (private$runs %||% 1 < 1) {
+      if (private$runs %||% 0 < 1) {
         if(is.null(session))
           session <- shiny::getDefaultReactiveDomain()
-        private$runs <- 1
+        if (isFALSE(private$runs %||% FALSE))
+          private$runs <- 1
         step <- step - 1
         session$sendCustomMessage("cicerone-start", list(step = step, id = private$id))
         private$run_once <- FALSE

--- a/R/steps.R
+++ b/R/steps.R
@@ -184,11 +184,15 @@ Cicerone <- R6::R6Class(
 #' @param session A valid Shiny session if `NULL` the function
 #' attempts to get the session with [shiny::getDefaultReactiveDomain()].
     start = function(step = 1, session = NULL){
-      if(is.null(session))
-        session <- shiny::getDefaultReactiveDomain()
-      
-      step <- step - 1
-      session$sendCustomMessage("cicerone-start", list(step = step, id = private$id))
+      if (private$run_once) {
+        if(is.null(session))
+          session <- shiny::getDefaultReactiveDomain()
+        
+        step <- step - 1
+        session$sendCustomMessage("cicerone-start", list(step = step, id = private$id))
+        private$run_once <- FALSE
+      }
+        
       invisible(self)
     },
 #' @details

--- a/man/Cicerone.Rd
+++ b/man/Cicerone.Rd
@@ -131,11 +131,10 @@ A Cicerone object.
   prev_btn_text = NULL,
   tab = NULL,
   tab_id = NULL,
+  is_id = NULL,
   on_highlighted = NULL,
   on_highlight_started = NULL,
-  on_next = NULL,
-  element,
-  onNext = NULL
+  on_next = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -167,6 +166,9 @@ options.}
 
 \item{\code{tab_id}}{The id of the tabs to activate in order to highlight \code{tab_id}.}
 
+\item{\code{is_id}}{\strong{Deprecated} Whether the selector passed to \code{el} is an HTML id, set to \code{FALSE} to use
+other selectors, e.g.: \code{.class}.}
+
 \item{\code{on_highlighted}}{A JavaScript function to run when the step is highlighted,
 generally a callback function. This is effectively a string that is evaluated JavaScript-side.}
 
@@ -175,10 +177,6 @@ highlighted, generally a callback function. This is effectively a string that is
 
 \item{\code{on_next}}{A JavaScript function to run when the next button is clicked (or its event triggered),
 generally a callback function. This is effectively a string that is evaluated JavaScript-side.}
-
-\item{\code{element}}{Same as above}
-
-\item{\code{onNext}}{alternative to above.}
 }
 \if{html}{\out{</div>}}
 }
@@ -192,7 +190,7 @@ Add a step.
 \if{latex}{\out{\hypertarget{method-init}{}}}
 \subsection{Method \code{init()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cicerone$init(session = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Cicerone$init(session = NULL, run_once = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -200,6 +198,8 @@ Add a step.
 \describe{
 \item{\code{session}}{A valid Shiny session if \code{NULL} the function
 attempts to get the session with \code{\link[shiny:domains]{shiny::getDefaultReactiveDomain()}}.}
+
+\item{\code{run_once}}{\code{(lgl)} whether to only run the guide once. \strong{DEFAULT: FALSE}}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
This adds `run_once` as a logical argument to `init` that is saved in the R6 private env.  The `start` method checks this arguments before running, and sets it to `FALSE` after one run.
This is for situations where returning to a tab would otherwise run a guide twice. 

If you think this argument would be better as an argument to the `initialize` method let me know!

Thanks!